### PR TITLE
Add timezone support scheduler input

### DIFF
--- a/@types/later.d.ts
+++ b/@types/later.d.ts
@@ -144,7 +144,7 @@ declare module '@breejs/later' {
        * @param dateFrom: The earliest a valid instance can occur
        * @param dateTo: The latest a valid instance can occur
        */
-      next(numberOfInst: number, dateFrom?: Date, dateTo?: Date): Date[] | Date;
+      next(numberOfInst: number, dateFrom?: Date | number, dateTo?: Date): Date[] | Date;
 
       /**
        * Finds the next valid range or ranges of the current schedule,
@@ -520,14 +520,14 @@ declare module '@breejs/later' {
        * @param callback - A callback called after first instance of recurrence pattern.
        * @param - A recurrence instance.
        */
-      setTimeout(callback: () => void, time: ScheduleData): Timer;
+      setTimeout(callback: () => void, time: ScheduleData, timezone?: string): Timer;
       /**
        * Set interval on window using given recurrence
        *
        * @param callback - A callback called after each instance of recurrence pattern.
        * @param - A recurrence instance.
        */
-      setInterval(callback: () => void, time: ScheduleData): Timer;
+      setInterval(callback: () => void, time: ScheduleData, timezone?: string): Timer;
 
       /**
        * time period information provider.

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -22,11 +22,13 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "amqp-cacoon": "^3.0.3",
-        "coronado-bridge": "^2.0.0",
+        "@breejs/later": "^4.1.0",
+        "@valtech-sd/rules-js": "^1.0.0",
+        "amqp-cacoon": "github:GiganticPlayground/amqp-cacoon#semver:^3.2.1",
+        "coronado-bridge": "github:GiganticPlayground/coronado-bridge#semver:^2.2.1",
         "lodash": "^4.17.21",
         "log4js": "^6.3.0",
-        "rules-js": "^1.0.0"
+        "p-queue": "^7.3.0"
       },
       "devDependencies": {
         "@types/amqp-connection-manager": "^2.0.12",
@@ -1593,14 +1595,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "../node_modules/moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "../node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1985,14 +1979,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../node_modules/rules-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rules-js/-/rules-js-1.0.0.tgz",
-      "integrity": "sha512-bm6FhqV31uwd9RViTiL+Lex2VKJ0yrDljyU7+u/oa8GhRIfQ2/y2Eez5vuMbd4oHkoJBoRIGngSJ4v4fsLTKiQ==",
-      "dependencies": {
-        "moment": "~2.24.0"
       }
     },
     "../node_modules/safe-buffer": {
@@ -3231,21 +3217,23 @@
     "rule-harvester": {
       "version": "file:..",
       "requires": {
+        "@breejs/later": "^4.1.0",
         "@types/amqp-connection-manager": "^2.0.12",
         "@types/amqplib": "^0.8.2",
         "@types/chai": "^4.2.21",
         "@types/lodash": "^4.14.172",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.7.2",
-        "amqp-cacoon": "^3.0.3",
+        "@valtech-sd/rules-js": "^1.0.0",
+        "amqp-cacoon": "github:GiganticPlayground/amqp-cacoon#semver:^3.2.1",
         "chai": "^4.3.4",
-        "coronado-bridge": "^2.0.0",
+        "coronado-bridge": "github:GiganticPlayground/coronado-bridge#semver:^2.2.1",
         "lodash": "^4.17.21",
         "log4js": "^6.3.0",
         "mocha": "^9.1.0",
         "nodemon": "^2.0.12",
+        "p-queue": "^7.3.0",
         "rimraf": "^3.0.2",
-        "rules-js": "^1.0.0",
         "sinon": "^11.1.2",
         "ts-node": "^10.2.1",
         "ts-sinon": "^2.0.1",
@@ -3439,8 +3427,7 @@
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
         },
         "amqp-cacoon": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/amqp-cacoon/-/amqp-cacoon-3.2.0.tgz",
+          "version": "https://registry.npmjs.org/amqp-cacoon/-/amqp-cacoon-3.2.0.tgz",
           "integrity": "sha512-y5C2NN339d59qnPog91NnWU9vVDfkEoK2EqkimfeJerXeJHGU82l13B9JwlT9wXHWGAfs8ZIH+9aP/PCH+ZqSw==",
           "requires": {
             "amqp-connection-manager": "~3.5.0",
@@ -3792,8 +3779,7 @@
           "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
         },
         "coronado-bridge": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/coronado-bridge/-/coronado-bridge-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/coronado-bridge/-/coronado-bridge-2.0.0.tgz",
           "integrity": "sha512-ZlKjBYMcScEJ9j0fgRim0RT3S7AGStmEB6GQ1FTxLFCWs3Dzs9DmMg6X1F3+wiiDlv8YwlY//8eu8ytLGom7Eg==",
           "requires": {
             "connect-timeout": "^1.9.0",
@@ -4471,11 +4457,6 @@
             }
           }
         },
-        "moment": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4761,14 +4742,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "rules-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/rules-js/-/rules-js-1.0.0.tgz",
-          "integrity": "sha512-bm6FhqV31uwd9RViTiL+Lex2VKJ0yrDljyU7+u/oa8GhRIfQ2/y2Eez5vuMbd4oHkoJBoRIGngSJ4v4fsLTKiQ==",
-          "requires": {
-            "moment": "~2.24.0"
           }
         },
         "safe-buffer": {

--- a/examples/src/example-scheduler-input.js
+++ b/examples/src/example-scheduler-input.js
@@ -33,7 +33,16 @@ const coreScheduledInput = new CoreInputScheduler(
     // This limits the queue size. The queue used for tasks will not grow beyond 100. 
     // For the example service, this should not come into play at all.
     defaultMaxPerTaskQueueLength: 100,
+    // timezoneConfig: 'America/New_York',
     tasks: [
+      // {
+      //   name: 'Specific time',
+      //   intervalText: 'at 3:41 pm',
+      //   input: {
+      //     directory: 'input_schedule_path/fast',
+      //     outputFilePrefix: 'scheduled-order-fast',
+      //   }, // Passed as part of the input facts in the scheduler
+      // },
       {
         name: 'Fast Orders',
         intervalText: 'every 15 seconds', // Could use intervalCron as an alternative

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@breejs/later": "^4.1.0",
+        "@breejs/later": "^4.2.0",
         "@valtech-sd/rules-js": "^1.0.0",
         "amqp-cacoon": "github:GiganticPlayground/amqp-cacoon#semver:^3.2.1",
         "coronado-bridge": "github:GiganticPlayground/coronado-bridge#semver:^2.2.1",
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@breejs/later": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@breejs/later/-/later-4.1.0.tgz",
-      "integrity": "sha512-QgGnZ9b7o4k0Ai1ZbTJWwZpZcFK9d+Gb+DyNt4UT9x6IEIs5HVu0iIlmgzGqN+t9MoJSpSPo9S/Mm51UtHr3JA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@breejs/later/-/later-4.2.0.tgz",
+      "integrity": "sha512-EVMD0SgJtOuFeg0lAVbCwa+qeTKILb87jqvLyUtQswGD9+ce2nB52Y5zbTF1Hc0MDFfbydcMcxb47jSdhikVHA==",
       "engines": {
         "node": ">= 10"
       }
@@ -2947,9 +2947,9 @@
   },
   "dependencies": {
     "@breejs/later": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@breejs/later/-/later-4.1.0.tgz",
-      "integrity": "sha512-QgGnZ9b7o4k0Ai1ZbTJWwZpZcFK9d+Gb+DyNt4UT9x6IEIs5HVu0iIlmgzGqN+t9MoJSpSPo9S/Mm51UtHr3JA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@breejs/later/-/later-4.2.0.tgz",
+      "integrity": "sha512-EVMD0SgJtOuFeg0lAVbCwa+qeTKILb87jqvLyUtQswGD9+ce2nB52Y5zbTF1Hc0MDFfbydcMcxb47jSdhikVHA=="
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha -r ts-node/register ./tests/**/*.test.ts"
   },
   "dependencies": {
-    "@breejs/later": "^4.1.0",
+    "@breejs/later": "^4.2.0",
     "@valtech-sd/rules-js": "^1.0.0",
     "amqp-cacoon": "github:GiganticPlayground/amqp-cacoon#semver:^3.2.1",
     "coronado-bridge": "github:GiganticPlayground/coronado-bridge#semver:^2.2.1",


### PR DESCRIPTION
- Add timezone support to task scheduler

NOTE: This is a somewhat hacky solution because later.js only partially support timezone but it does work. The main hacky part is around how we show the next scheduled time in logs. This is not be a major concern for functionality though.