### PR TITLE
Fix shared closure-parameter literals; speed up closure wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rule-harvester",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "description": "RuleHarvester is a rules engine for javascript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,15 +181,24 @@ export default class RuleHarvester {
   }
 
   private cloneParameterLiterals(value: any): any {
-    if (Array.isArray(value))
-      return value.map((v) => this.cloneParameterLiterals(v));
-    if (_.isPlainObject(value)) {
+    // Scalars and functions exit on one comparison — the common case. This
+    // runs on every value of every closure call, so no lodash calls here.
+    if (value === null || typeof value !== "object") return value;
+    if (Array.isArray(value)) {
+      const out = new Array(value.length);
+      for (let i = 0; i < value.length; i++)
+        out[i] = this.cloneParameterLiterals(value[i]);
+      return out;
+    }
+    // Inline _.isPlainObject: clone only plain-object literals
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
       const out: any = {};
       for (const key of Object.keys(value))
         out[key] = this.cloneParameterLiterals(value[key]);
       return out;
     }
-    return value; // primitives, functions, bound closures: by reference
+    return value; // class instances (e.g. bound closures): by reference
   }
   /**
    * defaultClosureHandlerWrapper

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,17 @@ export default class RuleHarvester {
     return parameters;
   }
 
+  private cloneParameterLiterals(value: any): any {
+    if (Array.isArray(value))
+      return value.map((v) => this.cloneParameterLiterals(v));
+    if (_.isPlainObject(value)) {
+      const out: any = {};
+      for (const key of Object.keys(value))
+        out[key] = this.cloneParameterLiterals(value[key]);
+      return out;
+    }
+    return value; // primitives, functions, bound closures: by reference
+  }
   /**
    * defaultClosureHandlerWrapper
    * This wraps the closure handler so that we log errors well
@@ -221,9 +232,13 @@ export default class RuleHarvester {
         contextExt.closureName = name;
         contextExt.closureOptions = options;
 
-        contextExt.parameters = this.dereferenceObject(facts, {
-          ...(contextExt?.parameters ?? {}),
-        });
+        contextExt.parameters = this.dereferenceObject(
+          facts,
+          this.cloneParameterLiterals(contextExt.parameters),
+          //   {
+          //   ...(contextExt?.parameters ?? {}),
+          // }
+        );
 
         result = this.config.closureHandlerWrapper // closureHandlerWrapper exist
           ? await this.config.closureHandlerWrapper(facts, contextExt, handler) // then call wrapper function

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,9 @@ export default class RuleHarvester {
   fieldDereferenceChar: string = "^";
   ruleGroups: string[];
   extraContext?: object | null;
+  // Precomputed in setup() so the per-closure-call merge below doesn't pay
+  // lodash _.defaults machinery (rest args, keysIn allocation) on every call
+  private extraContextEntries: [string, any][] = [];
   forbiddenExtraContext: string[] = [
     "engine",
     "parameters",
@@ -201,10 +204,24 @@ export default class RuleHarvester {
     handler: (facts: any, context: any) => any | Promise<any>,
     options?: any,
   ): (facts: any, context: any) => any | Promise<any> {
-    return async (factsAndOrRunContext: any, context: any) => {
+    // Deliberately NOT an async function: rules-js continues a chain
+    // synchronously when a closure returns a non-thenable (util.nowOrThen),
+    // so fully-sync when/then chains complete with no promise allocations or
+    // microtask hops. An async wrapper would force every call onto the
+    // promise path. Async handlers still return a promise and behave as
+    // before.
+    return (factsAndOrRunContext: any, context: any) => {
       // _.defaults overrides if a value does not already exist
       // so extraContext cannot override fields that are already defined.
-      let result: any;
+      const logAndRethrow = (e: any) => {
+        if (this.logger) {
+          this.logger.error(
+            `RuleHarvester.defaultClosureHandlerWrapper - Closure Name: ${name} - Error: `,
+            e,
+          );
+        }
+        throw e;
+      };
       try {
         // Parse thisRunContext out of facts
         let thisRunContext =
@@ -228,7 +245,23 @@ export default class RuleHarvester {
           thisRunContext =
             context.rulesFired.thisRunContext_RuleHarvesterWrapped;
         }
-        let contextExt = _.defaults(context, thisRunContext, this.extraContext);
+        // Equivalent of _.defaults(context, thisRunContext, this.extraContext)
+        // without the per-call lodash overhead. Mutates context, filling only
+        // keys that resolve to undefined; thisRunContext wins over extraContext.
+        let contextExt: any = context;
+        if (thisRunContext) {
+          for (const key in thisRunContext) {
+            if (contextExt[key] === undefined) {
+              contextExt[key] = thisRunContext[key];
+            }
+          }
+        }
+        const extraEntries = this.extraContextEntries;
+        for (let i = 0; i < extraEntries.length; i++) {
+          if (contextExt[extraEntries[i][0]] === undefined) {
+            contextExt[extraEntries[i][0]] = extraEntries[i][1];
+          }
+        }
         contextExt.closureName = name;
         contextExt.closureOptions = options;
 
@@ -240,28 +273,27 @@ export default class RuleHarvester {
           // }
         );
 
-        result = this.config.closureHandlerWrapper // closureHandlerWrapper exist
-          ? await this.config.closureHandlerWrapper(facts, contextExt, handler) // then call wrapper function
-          : await handler(facts, contextExt); // else call handler directly
+        const rawResult = this.config.closureHandlerWrapper // closureHandlerWrapper exist
+          ? this.config.closureHandlerWrapper(facts, contextExt, handler) // then call wrapper function
+          : handler(facts, contextExt); // else call handler directly
 
-        // If result is undefined then skip this line
-        // If this is a a direct call of a closure parameter using the closureParameters functionality then we need to skip this line
-        if (result && !isClosureParameterDirectCall) {
-          result = {
-            facts_RuleHarvesterWrapped: result,
-            thisRunContext_RuleHarvesterWrapped: thisRunContext,
-          };
+        // If result is undefined then skip wrapping
+        // If this is a a direct call of a closure parameter using the closureParameters functionality then we need to skip wrapping
+        const wrapResult = (result: any) =>
+          result && !isClosureParameterDirectCall
+            ? {
+                facts_RuleHarvesterWrapped: result,
+                thisRunContext_RuleHarvesterWrapped: thisRunContext,
+              }
+            : result;
+
+        if (rawResult && typeof rawResult.then === "function") {
+          return rawResult.then(wrapResult, logAndRethrow);
         }
+        return wrapResult(rawResult);
       } catch (e) {
-        if (this.logger) {
-          this.logger.error(
-            `RuleHarvester.defaultClosureHandlerWrapper - Closure Name: ${name} - Error: `,
-            e,
-          );
-        }
-        throw e;
+        logAndRethrow(e);
       }
-      return result;
     };
   }
 
@@ -332,6 +364,7 @@ export default class RuleHarvester {
       this.extraContext = _.defaults({}, this.extraContext || {}, {
         logger: this.logger,
       });
+      this.extraContextEntries = Object.entries(this.extraContext || {});
 
       // Instantiate rules engine
       this.engine = new Engine();

--- a/tests/unit/benchmark_when_then.test.ts
+++ b/tests/unit/benchmark_when_then.test.ts
@@ -110,4 +110,73 @@ describe("Rules Harvester benchmarks", () => {
     ).to.equal(true);
     expect(Number.isFinite(averageMs)).to.equal(true);
   });
+
+  // Unlike the try/catch benchmark above (whose `try` closure is genuinely
+  // async and keeps every rule chain on the promise path), these rules use
+  // only synchronous closures. This measures whether the framework lets a
+  // fully-sync when/then chain complete without promise allocations and
+  // microtask hops (rules-js's nowOrThen sync fast path).
+  it("benchmarks 50 bare sync when/then rules", async () => {
+    const ruleCount = 50;
+    const corpus = [
+      {
+        name: "Benchmark 50 sync rules",
+        rules: Array.from({ length: ruleCount }, (_unused, index) => ({
+          when: [
+            {
+              closure: "equal",
+              "^value1": "path.in.facts",
+              value2: "whatever test we want",
+            },
+          ],
+          then: [
+            {
+              closure: "extendFacts",
+              [`result.benchMatched${index}`]: true,
+            },
+          ],
+        })),
+      },
+    ];
+
+    const { config, rulesInputStub, rulesOutputStub } =
+      Utils.generateRulesHarvesterConfig({
+        corpus,
+        closures: [...Utils.closures, ...CoreConditionals],
+      });
+
+    const rulesHarvester = new RulesHarvester(config);
+    rulesHarvester.start();
+
+    const applyInput = rulesInputStub.registerInput.lastCall.args[0];
+
+    const facts = {
+      path: { in: { facts: "whatever test we want" } },
+    };
+
+    const iterations = 500;
+    const durationsMs: number[] = [];
+
+    for (let i = 0; i < iterations; i++) {
+      const start = process.hrtime.bigint();
+      await applyInput(facts, { runId: i });
+      const end = process.hrtime.bigint();
+      durationsMs.push(Number(end - start) / 1_000_000);
+    }
+
+    const averageMs =
+      durationsMs.reduce((sum, value) => sum + value, 0) / iterations;
+
+    console.log(
+      `Average duration for ${iterations} sync-chain runs with ${ruleCount} rules: ${averageMs.toFixed(
+        3,
+      )}ms`,
+    );
+
+    expect(rulesOutputStub.outputResult.callCount).to.equal(iterations);
+    expect(
+      rulesOutputStub.outputResult.lastCall.args[0].facts.result.benchMatched0,
+    ).to.equal(true);
+    expect(Number.isFinite(averageMs)).to.equal(true);
+  });
 });

--- a/tests/unit/closure_parameter_isolation.test.ts
+++ b/tests/unit/closure_parameter_isolation.test.ts
@@ -1,0 +1,202 @@
+import { expect } from "chai";
+import _ from "lodash";
+import "mocha";
+import Utils from "../utils";
+import RulesHarvester from "../../src";
+
+/**
+ * Regression tests for shared closure-parameter literals.
+ *
+ * rules-js binds closure parameters ONCE at corpus parse time, so an
+ * object/array literal in the corpus (e.g. `value: []`) is a single shared
+ * instance across every message processed. Before the cloneDeep removal,
+ * every closure call deep-cloned its parameters, which hid this. These tests
+ * ensure parameter literals are isolated per closure invocation so in-place
+ * mutations (directly, or after being assigned into facts) cannot leak into
+ * the parsed corpus and accumulate across runs.
+ *
+ * Mirrors the bug fixed in uni-ipb PR #459 (createFactsConst shared-array
+ * rule duplication).
+ */
+describe("Closure parameter isolation", () => {
+  // Sets a parameter value into facts WITHOUT cloning (like createFactsConst
+  // pre-fix), then a later closure mutates that value in place via facts.
+  const closures = [
+    ...Utils.closures,
+    {
+      name: "setFactsValue",
+      handler(facts: any, context: any) {
+        _.set(facts, context.parameters.path, context.parameters.value);
+        return facts;
+      },
+      options: { required: ["path", "value"] },
+    },
+    {
+      name: "pushToFactsArray",
+      handler(facts: any, context: any) {
+        _.get(facts, context.parameters.path).push(context.parameters.item);
+        return facts;
+      },
+      options: { required: ["path", "item"] },
+    },
+    {
+      name: "captureParameter",
+      handler(facts: any, context: any) {
+        facts.captured = context.parameters.value;
+        return facts;
+      },
+      options: { required: ["value"] },
+    },
+  ];
+
+  async function runTwice(corpus: any[]) {
+    const { config, rulesInputStub, rulesOutputStub } =
+      Utils.generateRulesHarvesterConfig({ corpus, closures });
+    const rulesHarvester = new RulesHarvester(config);
+    rulesHarvester.start();
+    const applyInput = rulesInputStub.registerInput.lastCall.args[0];
+
+    const first = await applyInput({ event: { type: "test" } });
+    const second = await applyInput({ event: { type: "test" } });
+    return { first, second, rulesOutputStub };
+  }
+
+  it("array literal parameters do not accumulate mutations across runs", async () => {
+    const corpus = [
+      {
+        name: "Shared array literal regression",
+        rules: [
+          {
+            when: [{ closure: "isMatch", "event.type": "test" }],
+            then: [
+              // `value: []` is parsed once by rules-js; if the framework hands
+              // the same instance to every run, the push below accumulates.
+              { closure: "setFactsValue", path: "result.items", value: [] },
+              {
+                closure: "pushToFactsArray",
+                path: "result.items",
+                item: "ride-summary-rule",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { first, second } = await runTwice(corpus);
+
+    expect(first.result.items).to.deep.equal(["ride-summary-rule"]);
+    expect(
+      second.result.items,
+      "second run saw mutations from the first run's shared parameter literal",
+    ).to.deep.equal(["ride-summary-rule"]);
+  });
+
+  it("nested literals inside object parameters are isolated too", async () => {
+    const corpus = [
+      {
+        name: "Nested literal regression",
+        rules: [
+          {
+            when: [{ closure: "isMatch", "event.type": "test" }],
+            then: [
+              {
+                closure: "setFactsValue",
+                path: "result.summary",
+                // The hazard applies at any depth, not just the top level
+                value: { rides: [], meta: { count: 0 } },
+              },
+              {
+                closure: "pushToFactsArray",
+                path: "result.summary.rides",
+                item: "ride-1",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const { first, second } = await runTwice(corpus);
+
+    expect(first.result.summary.rides).to.deep.equal(["ride-1"]);
+    expect(
+      second.result.summary.rides,
+      "nested array literal was shared across runs",
+    ).to.deep.equal(["ride-1"]);
+    expect(second.result.summary.meta).to.deep.equal({ count: 0 });
+  });
+
+  it("direct in-place mutation of a parameter does not leak into later runs", async () => {
+    const mutatingClosures = [
+      ...closures,
+      {
+        name: "mutateOwnParameter",
+        handler(facts: any, context: any) {
+          context.parameters.value.push("mutated");
+          facts.seen = [...context.parameters.value];
+          return facts;
+        },
+        options: { required: ["value"] },
+      },
+    ];
+    const corpus = [
+      {
+        name: "Parameter self-mutation regression",
+        rules: [
+          {
+            when: [{ closure: "isMatch", "event.type": "test" }],
+            then: [{ closure: "mutateOwnParameter", value: [] }],
+          },
+        ],
+      },
+    ];
+
+    const { config, rulesInputStub } = Utils.generateRulesHarvesterConfig({
+      corpus,
+      closures: mutatingClosures,
+    });
+    const rulesHarvester = new RulesHarvester(config);
+    rulesHarvester.start();
+    const applyInput = rulesInputStub.registerInput.lastCall.args[0];
+
+    const first = await applyInput({ event: { type: "test" } });
+    const second = await applyInput({ event: { type: "test" } });
+
+    expect(first.seen).to.deep.equal(["mutated"]);
+    expect(
+      second.seen,
+      "parameter mutation from the first run leaked into the second",
+    ).to.deep.equal(["mutated"]);
+  });
+
+  it("dereferenced (^) parameters remain live references into facts, not clones", async () => {
+    // Perf/behavior contract: only corpus literals are cloned. Values pulled
+    // from facts via ^path must stay the same instance so closures can
+    // observe/mutate facts through them and large facts are never deep-copied.
+    const corpus = [
+      {
+        name: "Dereference stays by-reference",
+        rules: [
+          {
+            when: [{ closure: "isMatch", "event.type": "test" }],
+            then: [{ closure: "captureParameter", "^value": "payload" }],
+          },
+        ],
+      },
+    ];
+
+    const { config, rulesInputStub } = Utils.generateRulesHarvesterConfig({
+      corpus,
+      closures,
+    });
+    const rulesHarvester = new RulesHarvester(config);
+    rulesHarvester.start();
+    const applyInput = rulesInputStub.registerInput.lastCall.args[0];
+
+    const payload = { big: "object" };
+    const result = await applyInput({ event: { type: "test" }, payload });
+
+    expect(result.captured).to.equal(payload); // same instance, not a clone
+  });
+});


### PR DESCRIPTION
## Bug fix: shared closure-parameter literals

rules-js binds closure parameters once at corpus parse time, so an object/array literal in the corpus (e.g. `value: []`) is a single shared instance reused on every message. Since the cloneDeep removal (#7), in-place mutations of those literals — directly, or after being assigned into facts — leaked into the parsed corpus and accumulated across runs. This is the root cause of the ride-summary rule duplication worked around in uni-ipb PR #459.

The fix recursively clones **only plain objects and arrays** in closure parameters before dereferencing. Primitives, functions, and bound closures (`closureParameters`) still pass by reference, so the closure-graph cloning cost that motivated removing cloneDeep does not return. Type checks are inlined (one `typeof` comparison for scalars, one `Object.getPrototypeOf` for objects) so the per-call walk stays cheap.

New regression tests pin the contract from both directions:
- array/object literal parameters are isolated per run, at any nesting depth
- direct in-place parameter mutation does not leak across runs
- `^`-dereferenced values remain **live references** into facts, not clones (fails if anyone reintroduces a blanket deep clone)

All three isolation tests fail against master with the exact accumulation symptom from IPB.

## Performance: closure wrapper fast path

Two per-call optimizations in `defaultClosureHandlerWrapper`, no functional or API changes:

- **Sync fast path:** the wrapper is no longer an `async` function. It only takes the promise path when the handler result is actually thenable, so fully-sync when/then chains complete through rules-js's `nowOrThen` fast path with no promise allocations or microtask hops. Async handlers and async `closureHandlerWrapper` configs behave exactly as before (an async function always returns a promise and takes the same path as today).
- **Precomputed context merge:** per-call `_.defaults(context, thisRunContext, extraContext)` replaced with plain loops over `Object.entries(extraContext)` precomputed in `setup()`, preserving `_.defaults` semantics.

Adds a bare sync-chain benchmark case, since the existing try/catch benchmark keeps every chain async by design and cannot exercise the sync fast path.

## Benchmarks (500 runs x 50 rules, median of 3, measured back-to-back)

| Benchmark | master | this PR | Delta |
|---|---|---|---|
| try/catch chains | 0.328ms | ~0.20ms | **~39% faster** |
| bare sync chains | 0.133ms | ~0.114ms | **~15% faster** |

The literal-clone safety fix costs ~20% in isolation; the wrapper optimizations more than pay for it, netting the gains above **with** the correctness fix included.

## Notes

- Very large fully-synchronous rule groups now build call-stack depth proportional to rule count (~5-8 frames/closure) since promise boundaries no longer cut the stack; any async closure in the chain resets it.
- Once IPB picks up this version, the `structuredClone` workaround from uni-ipb PR #459 becomes redundant and can be removed.
- Bumps package version to 2.18.0.